### PR TITLE
fix: crash on resizing macOS window

### DIFF
--- a/flutter_gl_macos/macos/Classes/FlutterGlMacosPlugin.swift
+++ b/flutter_gl_macos/macos/Classes/FlutterGlMacosPlugin.swift
@@ -98,7 +98,7 @@ public class FlutterGlMacosPlugin: NSObject, FlutterPlugin {
 
       let render = self.renders[textureId!];
 
-      let resp = render!.updateTexture(sourceTexture: sourceTexture!);
+      let resp = render?.updateTexture(sourceTexture: sourceTexture!);
 
       result(resp);  
     default:


### PR DESCRIPTION
The render is briefly `nil` and the `!` makes the app crash.